### PR TITLE
fixed Accept header separator

### DIFF
--- a/rdapper
+++ b/rdapper
@@ -597,7 +597,7 @@ sub request {
 
 	$req->header('Accept-Language',	$lang);
 	$req->header('Accept-Encoding',	$encoding);
-	$req->header('Accept',		'application/rdap+json;application/json');
+	$req->header('Accept',		'application/rdap+json,application/json');
 	$req->header('Authorization',	encode_base64($username.':'.$password)) if ($username ne '');
 	
 	my $res = $ua->request($req);


### PR DESCRIPTION
Hi,

I was playing with our RDAP server prototype using your rdapper client.

Our prototype is returning Content-Type: application/json; charset=utf-8 without actually paying attention to request Accept header and rdapper client was reporting HTTP 406 NOT ACCEPTABLE.

From RFC 2616 I have a feeling (based only on examples can't see it anywhere stated explicitly) that semicolon separates different properties of response while comma separates list of acceptable response.
http://www.w3.org/Protocols/rfc2616/rfc2616-sec14.html

I am not sure about your intentions but it's possible there should be comma instead of a semicolon.

Best regards

Jan Korous
