### PR TITLE
Do not use lib with relative paths

### DIFF
--- a/rdapper
+++ b/rdapper
@@ -1,5 +1,4 @@
 #!perl
-use lib qw(./lib);
 use App::rdapper;
 use strict;
 


### PR DESCRIPTION
It's a security flaw to add relative paths to %INC. If a victim executed rdapper while being in a directory writable by the attacker (e.g. /tmp), the attack could implant malicous code by placing a a file matching one of the modules loaded by rdapper.