### PR TITLE
use List::Util for `any` instead of List::MoreUtils

### DIFF
--- a/Makefile.PL
+++ b/Makefile.PL
@@ -12,8 +12,7 @@ WriteMakefile(
 	'PREREQ_PM'		=> {
         'Getopt::Long'      => 0,
         'JSON'              => 0,
-        'List::MoreUtils'   => 0,
-        'List::Util'        => 0,
+        'List::Util'        => '1.33',
         'Net::ASN'          => 0,
         'Net::DNS::Domain'  => 0,
         'Net::IP'           => 0,

--- a/lib/App/rdapper.pm
+++ b/lib/App/rdapper.pm
@@ -1,8 +1,7 @@
 package App::rdapper;
 use Getopt::Long qw(GetOptionsFromArray :config pass_through);
 use JSON;
-use List::Util qw(min max);
-use List::MoreUtils qw(any);
+use List::Util qw(any min max);
 use Net::ASN;
 use Net::DNS::Domain;
 use Net::IP;


### PR DESCRIPTION
Suggestion: use `List::Util` for `any` instead of `List::MoreUtils`.  The former comes bundled with Perl, and as of 1.33 includes an `any` function.