### PR TITLE
Defer loading PPI to run-time

### DIFF
--- a/lib/App/rdapper.pm
+++ b/lib/App/rdapper.pm
@@ -935,7 +935,7 @@ sub _ { decode($LH->encoding, $LH->maketext(@_)) }
 #
 sub export_strings {
     eval {
-        use PPI;
+        require PPI;
 
         my $doc = PPI::Document->new(__FILE__);
         $doc->prune(q{PPI::Token::Comment});


### PR DESCRIPTION
PPI is only used for updating a message catalog template. It is not used in normal use case. However, with the current code it's always loaded and because it's a large module it takes some time.

This patch defers loading of PPI to run-time, decreasing total rdapper run-time from 0.23 to 0.19 seconds on my system
(RDAPPER_LOCALE_DIR=./locale time -p perl -Ilib ./rdapper --version).

(If the purpose of eval in export_strings() is to hide the PPI dependency, then now it's good time to remove it from Makefile.PL.)