### PR TITLE
t/01-l10n.t: Skip tests properly

### DIFF
--- a/t/01-l10n.t
+++ b/t/01-l10n.t
@@ -37,19 +37,19 @@ plan tests => $total_tests;
 foreach my $lang_code ( sort keys %lang_tests ) {
     my $po_file = File::Spec->catfile('locale', $lang_code, 'LC_MESSAGES', 'rdapper.po');
 
-    unless (-f $po_file) {
-        diag("Skipping tests for '$lang_code': $po_file not found.");
-        next;
-    }
+    SKIP: {
+        skip("Skipping tests for '$lang_code': $po_file not found.",
+            scalar keys %{ $lang_tests{$lang_code} }) unless -f $po_file;
 
-    # Parse the .po file into a hash
-    my %translations = parse_po_file($po_file);
+        # Parse the .po file into a hash
+        my %translations = parse_po_file($po_file);
 
-    # Run the specific tests for this language
-    foreach my $original ( sort keys %{ $lang_tests{$lang_code} } ) {
-        my $expected = $lang_tests{$lang_code}->{$original};
-        my $translated = $translations{$original} // '';
-        is($translated, $expected, "[$lang_code] '$original' -> '$expected'");
+        # Run the specific tests for this language
+        foreach my $original ( sort keys %{ $lang_tests{$lang_code} } ) {
+            my $expected = $lang_tests{$lang_code}->{$original};
+            my $translated = $translations{$original} // '';
+            is($translated, $expected, "[$lang_code] '$original' -> '$expected'");
+        }
     }
 }
 


### PR DESCRIPTION
If a PO file is not found, e.g. the tests are run out of the source tree, t/01-l10n.t failed on mismatching test plan:

    t/01-l10n.t ..
    1..12
    # Skipping tests for 'de': locale/de/LC_MESSAGES/rdapper.po not found.
    # Skipping tests for 'es': locale/es/LC_MESSAGES/rdapper.po not found.
    # Skipping tests for 'fr': locale/fr/LC_MESSAGES/rdapper.po not found.
    # Skipping tests for 'pt': locale/pt/LC_MESSAGES/rdapper.po not found.
    not ok 1 - planned to run 12 but done_testing() expects 0

    #   Failed test 'planned to run 12 but done_testing() expects 0'
    #   at t/01-l10n.t line 56.
    # Looks like you planned 12 tests but ran 1.
    # Looks like you failed 1 test of 1 run.
    Dubious, test returned 1 (wstat 256, 0x100)
    Failed 12/12 subtests

This patch skips the tests using skip() to count the skipped tests properly.

(Next fix should be testing MO files instead of PO files.)